### PR TITLE
Add Code Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -487,6 +487,9 @@ $RECYCLE.BIN/
 # Vim temporary swap files
 *.swp
 
+# Coverage Reports
+coverage/*
+
 # Docusaurus
 /docs/node_modules/
 /docs/build/

--- a/README.md
+++ b/README.md
@@ -131,6 +131,16 @@ We welcome contributions from the community! In order to ensure the best experie
 
 We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/scottoffen/pipeforge/releases).
 
+## Test Coverage
+
+You can generate and open a test coverage report by running the following command in the project root:
+
+```bash
+pwsh ./test-coverage.ps1
+```
+
+> You must have [Powershell](https://learn.microsoft.com/en-us/powershell/) installed to run this command.
+
 ## License
 
 PipeForge is licensed under the [MIT](./LICENSE) license.

--- a/src/PipeForge.Tests.Steps/AssemblyInfo.cs
+++ b/src/PipeForge.Tests.Steps/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+using System.Diagnostics.CodeAnalysis;
+[assembly: ExcludeFromCodeCoverage]

--- a/src/PipeForge.Tests/PipelineTests.cs
+++ b/src/PipeForge.Tests/PipelineTests.cs
@@ -127,5 +127,35 @@ public class PipelineTests
         logger.ShouldContainMessage(string.Format(Pipeline.RunnerRegistrationMessage, runnerTypeName, lifetime), LogLevel.Debug);
     }
 
+    [Fact]
+    public void SafeGetTypes_ReturnsTypes_WhenNoException()
+    {
+        var expected = new[] { typeof(string), typeof(int) };
+
+        var result = Pipeline.SafeGetTypes(() => expected);
+
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void SafeGetTypes_ReturnsNonNullTypes_WhenReflectionTypeLoadException()
+    {
+        var expected = new[] { typeof(string), null, typeof(int) };
+
+        var ex = new ReflectionTypeLoadException(expected, new Exception[0]);
+
+        var result = Pipeline.SafeGetTypes(() => throw ex);
+
+        result.ShouldBe(new[] { typeof(string), typeof(int) });
+    }
+
+    [Fact]
+    public void SafeGetTypes_ReturnsEmpty_WhenUnknownException()
+    {
+        var result = Pipeline.SafeGetTypes(() => throw new InvalidOperationException());
+
+        result.ShouldBeEmpty();
+    }
+
     private class NotAContextWithSteps { }
 }

--- a/src/PipeForge/Adapters/IPipelineDiagnostics.cs
+++ b/src/PipeForge/Adapters/IPipelineDiagnostics.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace PipeForge.Adapters;
 
 internal interface IPipelineDiagnostics<T>
@@ -45,6 +47,7 @@ internal static class PipelineDiagnosticsFactory
     }
 }
 
+[ExcludeFromCodeCoverage]
 internal sealed class NullScope : IPipelineDiagnosticsScope
 {
     public static readonly NullScope Instance = new();

--- a/src/PipeForge/Adapters/NewtonsoftJsonSerializer.cs
+++ b/src/PipeForge/Adapters/NewtonsoftJsonSerializer.cs
@@ -1,8 +1,10 @@
 #if NETSTANDARD2_0
+using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
 namespace PipeForge.Adapters;
 
+[ExcludeFromCodeCoverage]
 internal class NewtonsoftJsonSerializer : IJsonSerializer
 {
     public string Serialize<T>(T obj) => JsonConvert.SerializeObject(obj, Formatting.Indented);

--- a/src/PipeForge/Adapters/SystemTextJsonSerializer.cs
+++ b/src/PipeForge/Adapters/SystemTextJsonSerializer.cs
@@ -1,9 +1,11 @@
 #if !NETSTANDARD2_0
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace PipeForge.Adapters;
 
+[ExcludeFromCodeCoverage]
 internal class SystemTextJsonSerializer : IJsonSerializer
 {
     private static readonly JsonSerializerOptions _options = new()

--- a/src/PipeForge/CompositionExtensions.cs
+++ b/src/PipeForge/CompositionExtensions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -71,6 +72,7 @@ public static class CompositionExtensions
     /// <typeparam name="TContext"></typeparam>
     /// <param name="services"></param>
     /// <returns></returns>
+    [ExcludeFromCodeCoverage]
     public static IServiceCollection AddPipelineFor<TContext>(this IServiceCollection services)
         where TContext : class
     {
@@ -89,6 +91,7 @@ public static class CompositionExtensions
     /// <param name="services"></param>
     /// <param name="environmentName"></param>
     /// <returns></returns>
+    [ExcludeFromCodeCoverage]
     public static IServiceCollection AddPipelineFor<TContext>(
         this IServiceCollection services,
         string? environmentName)
@@ -110,6 +113,7 @@ public static class CompositionExtensions
     /// <param name="environmentName"></param>
     /// <param name="lifetime"></param>
     /// <returns></returns>
+    [ExcludeFromCodeCoverage]
     public static IServiceCollection AddPipelineFor<TContext>(
         this IServiceCollection services,
         ServiceLifetime lifetime,
@@ -132,6 +136,7 @@ public static class CompositionExtensions
     /// <param name="markerType"></param>
     /// <param name="environmentName"></param>
     /// <returns></returns>
+    [ExcludeFromCodeCoverage]
     public static IServiceCollection AddPipelineFor<TContext>(
         this IServiceCollection services,
         Type markerType,
@@ -155,6 +160,7 @@ public static class CompositionExtensions
     /// <param name="environmentName"></param>
     /// <param name="lifetime"></param>
     /// <returns></returns>
+    [ExcludeFromCodeCoverage]
     public static IServiceCollection AddPipelineFor<TContext>(
         this IServiceCollection services,
         Type markerType,
@@ -178,6 +184,7 @@ public static class CompositionExtensions
     /// <param name="assembly"></param>
     /// <param name="environmentName"></param>
     /// <returns></returns>
+    [ExcludeFromCodeCoverage]
     public static IServiceCollection AddPipelineFor<TContext>(
         this IServiceCollection services,
         Assembly assembly,
@@ -201,6 +208,7 @@ public static class CompositionExtensions
     /// <param name="environmentName"></param>
     /// <param name="lifetime"></param>
     /// <returns></returns>
+    [ExcludeFromCodeCoverage]
     public static IServiceCollection AddPipelineFor<TContext>(
         this IServiceCollection services,
         Assembly assembly,
@@ -224,6 +232,7 @@ public static class CompositionExtensions
     /// <param name="assemblies"></param>
     /// <param name="environmentName"></param>
     /// <returns></returns>
+    [ExcludeFromCodeCoverage]
     public static IServiceCollection AddPipelineFor<TContext>(
         this IServiceCollection services,
         IEnumerable<Assembly> assemblies,

--- a/src/PipeForge/Pipeline.cs
+++ b/src/PipeForge/Pipeline.cs
@@ -3,6 +3,7 @@ using PipeForge.Metadata;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using System.Diagnostics.CodeAnalysis;
 
 namespace PipeForge;
 
@@ -27,6 +28,7 @@ public static class Pipeline
     /// <typeparam name="TContext"></typeparam>
     /// <param name="logger"></param>
     /// <returns></returns>
+    [ExcludeFromCodeCoverage]
     public static IEnumerable<PipelineStepDescriptor> Discover<TContext>(
         ILogger? logger = null)
         where TContext : class
@@ -46,6 +48,7 @@ public static class Pipeline
     /// <param name="environmentName"></param>
     /// <param name="logger"></param>
     /// <returns></returns>
+    [ExcludeFromCodeCoverage]
     public static IEnumerable<PipelineStepDescriptor> Discover<TContext>(
         string? environmentName,
         ILogger? logger = null)
@@ -66,6 +69,7 @@ public static class Pipeline
     /// <param name="typeMarker"></param>
     /// <param name="logger"></param>
     /// <returns></returns>
+    [ExcludeFromCodeCoverage]
     public static IEnumerable<PipelineStepDescriptor> Discover<TContext>(
         Type typeMarker,
         ILogger? logger = null)
@@ -87,6 +91,7 @@ public static class Pipeline
     /// <param name="environmentName"></param>
     /// <param name="logger"></param>
     /// <returns></returns>
+    [ExcludeFromCodeCoverage]
     public static IEnumerable<PipelineStepDescriptor> Discover<TContext>(
         Type typeMarker,
         string? environmentName,
@@ -108,6 +113,7 @@ public static class Pipeline
     /// <param name="assembly"></param>
     /// <param name="logger"></param>
     /// <returns></returns>
+    [ExcludeFromCodeCoverage]
     public static IEnumerable<PipelineStepDescriptor> Discover<TContext>(
         Assembly assembly,
         ILogger? logger = null)
@@ -129,6 +135,7 @@ public static class Pipeline
     /// <param name="environmentName"></param>
     /// <param name="logger"></param>
     /// <returns></returns>
+    [ExcludeFromCodeCoverage]
     public static IEnumerable<PipelineStepDescriptor> Discover<TContext>(
         Assembly assembly,
         string? environmentName,
@@ -150,6 +157,7 @@ public static class Pipeline
     /// <param name="assemblies"></param>
     /// <param name="logger"></param>
     /// <returns></returns>
+    [ExcludeFromCodeCoverage]
     public static IEnumerable<PipelineStepDescriptor> Discover<TContext>(
         IEnumerable<Assembly> assemblies,
         ILogger? logger = null)
@@ -181,7 +189,7 @@ public static class Pipeline
         var stepInterface = typeof(IPipelineStep<TContext>);
 
         var descriptors = assemblies
-            .SelectMany(SafeGetTypes)
+            .SelectMany(a => SafeGetTypes(() => a.GetTypes()))
             .Where(t => !t.IsAbstract && !t.IsInterface && stepInterface.IsAssignableFrom(t) && t.GetCustomAttribute<PipelineStepAttribute>() != null)
             .Select(t => new PipelineStepDescriptor(t))
             .Where(d => d.Environment == null || d.Environment.Equals(environmentName, StringComparison.OrdinalIgnoreCase))
@@ -223,6 +231,7 @@ public static class Pipeline
     /// <param name="services"></param>
     /// <param name="descriptors"></param>
     /// <param name="logger"></param>
+    [ExcludeFromCodeCoverage]
     public static void Register<TContext>(
         IServiceCollection services,
         IEnumerable<PipelineStepDescriptor> descriptors,
@@ -319,11 +328,11 @@ public static class Pipeline
     /// <summary>
     /// Safely retrieves all loadable types from the specified assembly, skipping those that cannot be loaded.
     /// </summary>
-    private static IEnumerable<Type> SafeGetTypes(Assembly assembly)
+    internal static IEnumerable<Type> SafeGetTypes(Func<Type[]> getTypes)
     {
         try
         {
-            return assembly.GetTypes();
+            return getTypes();
         }
         catch (ReflectionTypeLoadException ex)
         {

--- a/src/PipeForge/PipelineStep.cs
+++ b/src/PipeForge/PipelineStep.cs
@@ -1,6 +1,9 @@
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace PipeForge;
 
+[ExcludeFromCodeCoverage]
 public abstract class PipelineStep<T> : IPipelineStep<T>
 {
     public string? Description { get; set; } = null;

--- a/src/coverlet.runsettings
+++ b/src/coverlet.runsettings
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <!-- Enable attribute-based exclusion -->
+          <ExcludeByAttribute>ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
+
+          <!-- You can also add others if desired -->
+          <!-- <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute> -->
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/test-coverage.ps1
+++ b/test-coverage.ps1
@@ -1,0 +1,34 @@
+#!/usr/bin/env pwsh
+# test-coverage.ps1
+
+$ErrorActionPreference = "Stop"
+
+# Run tests and collect coverage
+dotnet test src --collect:"XPlat Code Coverage" --settings src/coverlet.runsettings
+
+# Find the most recent coverage file
+$coverageFile = Get-ChildItem -Recurse -Filter "coverage.cobertura.xml" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+
+if (-not $coverageFile) {
+    Write-Error "❌ No coverage file found."
+    exit 1
+}
+
+# Generate the report
+reportgenerator `
+  -reports:$coverageFile.FullName `
+  -targetdir:"coverage" `
+  -reporttypes:"HtmlInline_AzurePipelines;TextSummary"
+
+# Open report in default browser
+$indexPath = Join-Path "coverage" "index.html"
+
+if ($IsWindows) {
+    Start-Process $indexPath
+} elseif ($IsMacOS) {
+    open $indexPath
+} elseif ($IsLinux) {
+    xdg-open $indexPath
+} else {
+    Write-Warning "Platform not detected — open coverage-report/index.html manually"
+}


### PR DESCRIPTION
Code coverage reports can now be generated locally using the command:

```
```

> [!INFORMATION]
> Powershell is required to be installed, as well as the global [ReportGenerator](https://www.nuget.org/packages/ReportGenerator) tool